### PR TITLE
Edit known open source projects using WCA OAuth

### DIFF
--- a/knowledge_base/v0_api.md
+++ b/knowledge_base/v0_api.md
@@ -50,9 +50,10 @@ Known open source projects using WCA OAuth:
 - [speedcubingfrance.org](https://speedcubingfrance.org/) - GitHub: [speedcubingfrance/speedcubingfrance.org](https://github.com/speedcubingfrance/speedcubingfrance.org)
 - [Scrambles Matcher](https://viroulep.github.io/scrambles-matcher/) - GitHub: [viroulep/scrambles-matcher](https://github.com/viroulep/scrambles-matcher)
 - [WCA Live](https://live.worldcubeassociation.org) - GitHub: [thewca/wca-live](https://github.com/thewca/wca-live)
-- [Delegate Dashboard](https://delegate-dashboard.netlify.app/) - GitHub: [coder13/delegateDashboard](https://coder13/delegateDashboard)
-- [Groupifier](https://groupifier.jonatanklosko.com/) - GitHub: [jonatanklosko/groupifier](https://jonatanklosko/groupifier)
+- [Delegate Dashboard](https://delegate-dashboard.netlify.app/) - GitHub: [coder13/delegateDashboard](https://github.com/coder13/delegateDashboard)
+- [Groupifier](https://groupifier.jonatanklosko.com/) - GitHub: [jonatanklosko/groupifier](https://github.com/jonatanklosko/groupifier)
 - [Badgifier](https://dallasmcneil.com/projects/badgifier/) 
+- [Speedcubing Slovakia](https://speedcubingslovakia.sk) - Github: [jakubdrobny/speedcubingslovakia](https://github.com/jakubdrobny/speedcubingslovakia)
 
 ## Staging OAuth Application 
 


### PR DESCRIPTION
1. Edited broken links to GIthub of 2 apps.
2. Added link to my app for our regional organization (Speedcubing Slovakia), which hosts weekly online competitions and is using WCA OAuth. it is open source and it's backend is written in Go, so I thought it would be nice to link in the docs, if someone else happens to use WCA OAuth in Go. (it's not perfect implementation, but may serve as a starting point)

Let me know what you think about it.