### PR TITLE
add base64, logger and csv to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'https://rubygems.org'
 
+gem "base64" 
+gem "logger"
+gem "csv"
+
 gem "jekyll", "~> 4.3.2" # installed by `gem jekyll`
 # gem "webrick"        # required when using Ruby >= 3 and Jekyll <= 4.2.2
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,6 @@
 source 'https://rubygems.org'
 
-gem "base64" 
-gem "logger"
-gem "csv"
-
-gem "jekyll", "~> 4.3.2" # installed by `gem jekyll`
+gem "jekyll", "~> 4.4.0" # installed by `gem jekyll`
 # gem "webrick"        # required when using Ruby >= 3 and Jekyll <= 4.2.2
 
 gem "just-the-docs", "0.6.1" # pinned to the current release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,17 +45,20 @@ GEM
     http_parser.rb (0.8.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.4)
+    jekyll (4.4.1)
       addressable (~> 2.4)
+      base64 (~> 0.2)
       colorator (~> 1.0)
+      csv (~> 3.0)
       em-websocket (~> 0.5)
       i18n (~> 1.0)
       jekyll-sass-converter (>= 2.0, < 4.0)
       jekyll-watch (~> 2.0)
+      json (~> 2.6)
       kramdown (~> 2.3, >= 2.3.1)
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (>= 0.3.6, < 0.5)
+      mercenary (~> 0.3, >= 0.3.6)
       pathutil (~> 0.9)
       rouge (>= 3.0, < 5.0)
       safe_yaml (~> 1.0)
@@ -69,6 +72,7 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    json (2.10.2)
     just-the-docs (0.6.1)
       jekyll (>= 3.8.5)
       jekyll-include-cache
@@ -82,7 +86,6 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.4)
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -154,11 +157,8 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  base64
-  csv
-  jekyll (~> 4.3.2)
+  jekyll (~> 4.4.0)
   just-the-docs (= 0.6.1)
-  logger
 
 BUNDLED WITH
    2.6.8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,51 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.5)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.9)
     colorator (1.1.0)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.5)
+    csv (3.3.2)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.15.5)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
     forwardable-extended (2.6.0)
-    google-protobuf (3.24.2-x86_64-linux)
+    google-protobuf (4.30.2)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.2-aarch64-linux)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.2-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.2-x86-linux)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.2-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.2-x86_64-linux)
+      bigdecimal
+      rake (>= 13)
     http_parser.rb (0.8.0)
-    i18n (1.14.1)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.2)
+    jekyll (4.3.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -33,8 +63,8 @@ GEM
       webrick (~> 1.7)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
-    jekyll-sass-converter (3.0.0)
-      sass-embedded (~> 1.54)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
@@ -44,38 +74,91 @@ GEM
       jekyll-include-cache
       jekyll-seo-tag (>= 2.0)
       rake (>= 12.3.1)
-    kramdown (2.4.0)
-      rexml
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
-    listen (3.8.0)
+    listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.4)
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.3)
-    rake (13.0.6)
+    public_suffix (6.0.1)
+    rake (13.2.1)
     rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.2.6)
-    rouge (4.1.3)
+    rexml (3.4.1)
+    rouge (4.5.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.66.1-x86_64-linux-gnu)
-      google-protobuf (~> 3.23)
+    sass-embedded (1.86.3)
+      google-protobuf (~> 4.30)
+      rake (>= 13)
+    sass-embedded (1.86.3-aarch64-linux-android)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-aarch64-linux-gnu)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-aarch64-linux-musl)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-arm-linux-androideabi)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-arm-linux-gnueabihf)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-arm-linux-musleabihf)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-arm64-darwin)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-riscv64-linux-android)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-riscv64-linux-gnu)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-riscv64-linux-musl)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-x86_64-darwin)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-x86_64-linux-android)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-x86_64-linux-gnu)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-x86_64-linux-musl)
+      google-protobuf (~> 4.30)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    unicode-display_width (2.4.2)
-    webrick (1.8.1)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
 
 PLATFORMS
+  aarch64-linux
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  x86-linux
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
   x86_64-linux
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
+  base64
+  csv
   jekyll (~> 4.3.2)
   just-the-docs (= 0.6.1)
+  logger
 
 BUNDLED WITH
-   2.3.26
+   2.6.8


### PR DESCRIPTION
Apparently, base64, logger and csv are "not part of the default gems starting from Ruby 3.5.0.
 
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/14333767-2b3e-4842-97c5-a9784adb04b3" />
