### PR TITLE
fix Guides>Miscellaneous page title

### DIFF
--- a/guides/misc_notes.md
+++ b/guides/misc_notes.md
@@ -1,5 +1,5 @@
 ---
-title: Creating React Components
+title: Miscelaneous
 parent: Guides
 layout: default
 ---


### PR DESCRIPTION
I wasn't too sure what this page should actually be called, because there is only one section there at the moment, but certainly not "Creating React Components". For now I named it based on the file name. Any better ideas?